### PR TITLE
bug: Fixes the typo mistake into landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <h1>Samon Game</h1>
-    <h2>Pres any to start the game</h2>
+    <h2>Pres any key to start the game</h2>
 
     <div class="btn-container">
         <div class="line-one">


### PR DESCRIPTION
The sub-heading "Press any to start the game" of the landing page is now "Press any key to start the game".

fixes #3 